### PR TITLE
Update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,7 +28,7 @@ git clone https://github.com/WebKit/WebKit.git WebKit
 
 Install Xcode and its command line tools if you haven't done so already:
 
-1. **Install Xcode** Get Xcode from https://developer.apple.com/downloads. To build WebKit for OS X, Xcode 5.1.1 or later is required. To build WebKit for iOS Simulator, Xcode 7 or later is required.
+1. **Install Xcode** Get Xcode from https://developer.apple.com/downloads. To build WebKit for macOS, Xcode 5.1.1 or later is required. To build WebKit for iOS Simulator, Xcode 7 or later is required.
 2. **Install the Xcode Command Line Tools** In Terminal, run the command: `xcode-select --install`
 
 Run the following command to build a debug build with debugging symbols and assertions:


### PR DESCRIPTION
The phrase "OS X" has been replaced by "macOS" in more recent versions of the macOS operating system. Therefore, it should be corrected to:

"To build WebKit for macOS, Xcode 5.1.1 or later is required."

This change reflects the updated naming convention for the macOS operating system.

# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
